### PR TITLE
 equals(), hashcode() 에서 필드 접근을 getter로 바꾸기

### DIFF
--- a/src/main/java/com/fastcampus/projectboard/domain/Article.java
+++ b/src/main/java/com/fastcampus/projectboard/domain/Article.java
@@ -52,11 +52,11 @@ public class Article extends AuditingFields {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof Article that)) return false;
-        return id != null && id.equals(that.getId());
+        return this.getId() != null && this.getId().equals(that.getId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }

--- a/src/main/java/com/fastcampus/projectboard/domain/ArticleComment.java
+++ b/src/main/java/com/fastcampus/projectboard/domain/ArticleComment.java
@@ -38,11 +38,11 @@ public class ArticleComment extends AuditingFields {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof ArticleComment that)) return false;
-        return id != null && id.equals(that.getId());
+        return this.getId() != null && this.getId().equals(that.getId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }

--- a/src/main/java/com/fastcampus/projectboard/domain/UserAccount.java
+++ b/src/main/java/com/fastcampus/projectboard/domain/UserAccount.java
@@ -45,12 +45,12 @@ public class UserAccount extends AuditingFields {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof UserAccount that)) return false;
-        return userId != null && userId.equals(that.getUserId());
+        return this.getUserId() != null && this.getUserId().equals(that.getUserId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(userId);
+        return Objects.hash(this.getUserId());
     }
 
 }


### PR DESCRIPTION
스프링 데이터 JPA로 엔티티를 다룰 떄, 엔티티 데이터는 하이버네이트 구현체가 만든 프록시 객체를 이용하여 지연 로딩될 수 있다. 따라서 엔티티를 조회할때 필드에 직접 접근하면  id == null인 상황( id 자동생성으로인한 미생성) 있을 수 있고, 이러면 올바른 비교를 하지 못한다.  getter를 사용하면 이러한 문제를 예방 할 수 있다.

This closes #70 